### PR TITLE
Added map_sell_land action and sellLand module

### DIFF
--- a/src/main/goal/nl/tudelft/ti2806/Service.mas2g
+++ b/src/main/goal/nl/tudelft/ti2806/Service.mas2g
@@ -4,8 +4,9 @@
 % - The agent uses the 1.0.8/context version of the environment.
 
 use "tygronenv-1.0.8-C-jar-with-dependencies.jar" as environment with
-	project = "emptytestmap",
-	stakeholder = "MUNICIPALITY" .
+	project = "basictestmap",
+	stakeholder = "COMPANY",
+	domain = "tudelft".
  
 define serviceAgent as agent {
 	use service as main module.

--- a/src/main/goal/nl/tudelft/ti2806/sellLand.mod2g
+++ b/src/main/goal/nl/tudelft/ti2806/sellLand.mod2g
@@ -3,6 +3,17 @@ use service as actionspec.
 
 exit = always.
 
+% sellLand:
+% - states: 1
+% - description: Prompts the owner of the specified MultiPolygon square the agent wants to buy that land.
 module sellLand {
-	
+	% description: Sells the specified MultiPolygon square if possible.
+	% if:
+	% - true
+	% then:
+	% - Buys the specified MultiPolygon square for the specified price.
+	if 
+		true
+	then 
+		map_sell_land(0,square(100,200,85,55), 1).
 }

--- a/src/main/goal/nl/tudelft/ti2806/sellLand.mod2g
+++ b/src/main/goal/nl/tudelft/ti2806/sellLand.mod2g
@@ -5,13 +5,13 @@ exit = always.
 
 % sellLand:
 % - states: 1
-% - description: Prompts the owner of the specified MultiPolygon square the agent wants to buy that land.
+% - description: Prompts a stakeholder that the agent wants to sell the specified MultiPolygon square to that proposed buyer.
 module sellLand {
 	% description: Sells the specified MultiPolygon square if possible.
 	% if:
 	% - true
 	% then:
-	% - Buys the specified MultiPolygon square for the specified price.
+	% - Sells the specified MultiPolygon square for the specified price.
 	if 
 		true
 	then 

--- a/src/main/goal/nl/tudelft/ti2806/service.act2g
+++ b/src/main/goal/nl/tudelft/ti2806/service.act2g
@@ -31,7 +31,7 @@ define	map_buy_land(MultiPolygon, Price) with
 % - sell a piece of land for a specified price to a proposed buyer
 % parameters:
 % -	BuyerId: The Stakeholder ID of the proposed buyer.
-% - MultiPolygon: Polygon (like square) which should be bought
+% - MultiPolygon: Polygon (like square) which should be sold
 % - Price: The amount of euros per m^2
 define	map_sell_land(BuyerId,MultiPolygon, Price) with
 	pre{ true }

--- a/src/main/goal/nl/tudelft/ti2806/service.act2g
+++ b/src/main/goal/nl/tudelft/ti2806/service.act2g
@@ -26,3 +26,13 @@ define	building_plan_demolish(BuildId) with
 define	map_buy_land(MultiPolygon, Price) with
 	pre{ true }
 	post{ true}
+
+% description:
+% - sell a piece of land for a specified price to a proposed buyer
+% parameters:
+% -	BuyerId: The Stakeholder ID of the proposed buyer.
+% - MultiPolygon: Polygon (like square) which should be bought
+% - Price: The amount of euros per m^2
+define	map_sell_land(BuyerId,MultiPolygon, Price) with
+	pre{ true }
+	post{ true}

--- a/src/main/goal/nl/tudelft/ti2806/service.mod2g
+++ b/src/main/goal/nl/tudelft/ti2806/service.mod2g
@@ -5,6 +5,7 @@ use demolish as module.
 use buildConvenienceStore as module.
 use buildSportsCenter as module.
 use buyLand as module.
+use sellLand as module.
 use demolish as module.
 
 exit = nogoals.


### PR DESCRIPTION
As a virtual human, I want to be able to sell redundant property to other stakeholders.
Unnecessary land can be sold for a set price to a specified stakeholder.

`map_sell_land(<BuyerId>, <Multipolygon>, <Price>)`
`<BuyerId>`: The proposed buyer of the property
`<Multipolygon>`: The multipolygon to be sold
`<Price>`: The price in euro's per m^2